### PR TITLE
feat(volumeCTL): add volume controller

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Tetris | @monuelo</title>
   <meta name="description" content="I just wanted to play tetris, so I decided to make my own.">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" integrity="sha512-KfkfwYDsLkIlwQp6LFnl8zNdLGxu9YAA1QvwINks4PhcElQSvqcyVLLD9aMhXd13uQjoXtEKNosOWaZqXgel0g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" type="text/css" href="style.css">
   <link rel="shortcut icon" href="./assets/logo.png" type="image/x-icon">
   <base target="_top">
@@ -71,7 +72,21 @@
         <td>M</td>
       </tr>
     </table>
+    <div class="control-container">
+      <div class="volume-control">
+        <div class="speaker"><i class="fas fa-volume-off"></i></div>
+          <div class="bars">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <input type="range" min="0" max="100" step="20" value="60">
+          </div>
+      </div>
+    </div>
   </div>
+  
   <div class="canvas-area">
     <canvas id="tetris" width="240" height="400"></canvas>
     <ul class="sidebar group">

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,10 @@ const tetris = new Tetris({
   nextPiece,
   hold,
 });
+const allSounds = document.getElementsByTagName("audio");
+const controlBox = document.getElementsByClassName("control-container")[0];
+const volumeControl = controlBox.querySelector(".volume-control");
+const volumeInput = volumeControl.querySelector("input[type=range]");
 
 const gameSongs = new GameSongs({
   themeSong: new Sound({ src: "./assets/tetris.mp3", loop: true }),
@@ -21,6 +25,30 @@ document.querySelector("#play").onclick = () => {
   home.style.display = "none";
   tetris.init();
 };
+
+const setVolume = () => {
+  const setVolumeLevel = parseInt(volumeInput.value);
+  volumeControl.className = "volume-control";
+
+  [...allSounds].forEach((_, i) => { allSounds[i].volume = setVolumeLevel / 100; });
+
+  if (setVolumeLevel > 0) {
+    controlBox.classList.add("volume-on");
+    volumeControl.classList.add("volume-" + setVolumeLevel);
+  } else {
+    controlBox.classList.remove("volume-on");
+  }
+  tetris.musicPaused ? tetris.toggleMusic() : ''; 
+}; 
+
+const muteMusic = () => {
+  tetris.toggleMusic()   
+  controlBox.classList.contains("volume-on") ? controlBox.classList.remove("volume-on") : 
+  controlBox.classList.add("volume-on");
+}; 
+
+volumeInput.addEventListener("mousemove", setVolume);
+setVolume();
 
 document.addEventListener("keydown", (event) => {
   if (!tetris.paused && !tetris.board.over) {
@@ -47,7 +75,7 @@ document.addEventListener("keydown", (event) => {
         tetris.player.swap();
         return;
       case 77:
-        tetris.toggleMusic()
+        muteMusic();
         return;
     }
   }

--- a/style.css
+++ b/style.css
@@ -114,3 +114,117 @@ ul {
 #score {
   margin-top: 20px;
 }
+
+.control-box.volume-on .icon {
+	color: #5AF1F0;
+}
+
+.volume-control {
+  margin: 10px;
+  width: 100%;
+  height: 40px;
+  display: flex;
+  align-items: baseline;
+}
+
+.volume-control .speaker {
+  font-size: 35px;
+  font-weight: 600;
+  line-height: 1;
+  color: #fff;
+  text-shadow: 3px 3px 0 rgba(0, 0, 0, 0.2);
+  transition: 0.3s ease-in-out;
+}
+
+.control-container.volume-on .volume-control .speaker {
+  color: #5AF1F0;
+}
+
+.volume-control .bars {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  margin-left: 20px;
+  width: 48%; 
+  height: 80%;
+}
+
+.volume-control .bars .bar {
+  width: 14%;
+  margin: 0 3%;
+  background-color: #bbb;
+  transition: 0.3s ease-in-out;
+}
+
+.volume-control .bars .bar:nth-child(1) {
+  height: 20%;
+}
+
+.volume-control .bars .bar:nth-child(2) {
+  height: 40%;
+}
+
+.volume-control .bars .bar:nth-child(3) {
+  height: 60%;
+}
+
+.volume-control .bars .bar:nth-child(4) {
+  height: 80%;
+}
+
+.volume-control .bars .bar:nth-child(5) {
+  height: 100%;
+}
+
+.volume-control .bars input[type='range'] {
+  position: absolute;
+  left: -10%;
+  width: 110%;
+  height: 100%;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.volume-control.volume-20 .bars .bar:nth-child(1),
+.volume-control.volume-40 .bars .bar:nth-child(1),
+.volume-control.volume-60 .bars .bar:nth-child(1),
+.volume-control.volume-80 .bars .bar:nth-child(1),
+.volume-control.volume-100 .bars .bar:nth-child(1),
+.volume-control.volume-40 .bars .bar:nth-child(2),
+.volume-control.volume-60 .bars .bar:nth-child(2),
+.volume-control.volume-80 .bars .bar:nth-child(2),
+.volume-control.volume-100 .bars .bar:nth-child(2),
+.volume-control.volume-60 .bars .bar:nth-child(3),
+.volume-control.volume-80 .bars .bar:nth-child(3),
+.volume-control.volume-100 .bars .bar:nth-child(3),
+.volume-control.volume-80 .bars .bar:nth-child(4),
+.volume-control.volume-100 .bars .bar:nth-child(4),
+.volume-control.volume-100 .bars .bar:nth-child(5) {
+  background-color: #5AF1F0;
+}
+
+@media (max-width: 1500px) {
+  .volume-control {
+    height: 30px;
+  }
+  .volume-control .speaker {
+    font-size: 25px;
+  }
+  .volume-control .bars {
+    margin-left: 10px;
+    width: 45%;
+  }
+}
+
+@media (max-width: 600px) {
+  .volume-control {
+    height: 20px;
+  }
+  .volume-control .speaker {
+    font-size: 15px;
+  }
+  .volume-control .bars {
+    margin-left: 5px;
+    width: 35%;
+  }
+}


### PR DESCRIPTION
Issue #15: Create a Volume Controller for Music

The issue above has been implemented. A speaker icon along with a range for volume control was added. The speaker icon displays if the music is muted or not, and the volume bars represent the current volume for the game. The game noises can also be muted if the user wishes by moving the volume bar down to zero. I figure some players might want to keep game noises on, but the music off to listen to other stuff. Volume is adjusted via the mouse. If the user interacts with the volume bars while previously muted, it will unmute the music. Feature has responsive design.

### **_Music and game noises on_**

![i-just-want-to-play-tetris](https://user-images.githubusercontent.com/77213293/174010286-be803098-009c-4583-a560-c16f71f1e8b6.png)

### **_Music off, game noises on_**

![i-just-want-to-play-tetris_2](https://user-images.githubusercontent.com/77213293/174012320-f7d641c4-739d-4586-aaa0-c1d85fa34f9a.png)

### **_Music and game noises off_**

![i-just-want-to-play-tetris_3](https://user-images.githubusercontent.com/77213293/174012352-7cc9b82f-4713-4775-8e7d-6337e029d8a0.png)

 